### PR TITLE
Fix chromatic workflow

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 
 jobs:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -10,9 +10,20 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.2
-      - run: cd client && yarn
-      - uses: chromaui/action@v1
+      - name: Checkout repository
+        uses: actions/checkout@v2.4.2
         with:
+          fetch-depth: 0
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3.4.1
+        with:
+          node-version: 16.16.0
+      - name: Install dependencies
+        working-directory: client
+        run: yarn
+      - name: Publis to Chromatic
+        uses: chromaui/action@v1
+        with:
+          workingDir: client
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,9 +1,9 @@
 name: Chromatic Deployment
 
 on: 
-  push:
-    branches:
-      - main
+  # push:
+  #   branches:
+  #     - main
   workflow_dispatch:
 
 

--- a/README.md
+++ b/README.md
@@ -188,4 +188,6 @@ When transferring large file, we need to care about memory in receiver side. If 
 We can use filesystem API but it is deprecated. That's why I use [StreamSaver.js](https://github.com/jimmywarting/StreamSaver.js) to avoid memory issue.
 
 
+## Storybook
+WIP
 


### PR DESCRIPTION
## Description
Because orka is kind of monorepo, we need to specify working directory.
Plus, until orka stabilizes I comment out `push branches` trigger.