### PR TITLE
write db schema

### DIFF
--- a/client/src/database/schema.sql
+++ b/client/src/database/schema.sql
@@ -1,0 +1,44 @@
+CREATE TABLE IF NOT EXISTS users (
+    id CHAR(16) PRIMARY KEY,
+    name VARCHAR(50) NOT NULL,
+    profile INT8 NOT NULL
+);
+-- data: file type
+CREATE TABLE IF NOT EXISTS files (
+    id CHAR(16) PRIMARY KEY,
+    name VARCHAR(50) NOT NULL,
+    size INT32 NOT NULL,
+    download_count INT16 NOT NULL,
+    hands_up BOOLEAN NOT NULL,
+    uploaded_by CHAR(16) NOT NULL,
+    uploaded_at TIMESTAMP NOT NULL
+);
+-- data: link type
+CREATE TABLE IF NOT EXISTS links (
+    id CHAR(16) PRIMARY KEY,
+    text TEXT NOT NULL,
+    view_count INT16 NOT NULL,
+    hands_up BOOLEAN NOT NULL,
+    uploaded_by CHAR(16) NOT NULL,
+    uploaded_at TIMESTAMP NOT NULL
+);
+CREATE TABLE IF NOT EXISTS comments (
+    id CHAR(16) PRIMARY KEY,
+    data_id CHAR(16) NOT NULL,
+    data_type VARCHAR(16) NOT NULL,
+    text TEXT NOT NULL,
+    sender_id CHAR(16) NOT NULL,
+    receiver_id CHAR(16) NOT NULL,
+    created_at TIMESTAMP NOT NULL
+);
+CREATE TABLE IF NOT EXISTS comment_metadata (
+    data_id CHAR(16) PRIMARY KEY,
+    last_read_comment_id CHAR(16)
+);
+CREATE TABLE IF NOT EXISTS notifications (
+    id CHAR(16) PRIMARY KEY,
+    text TEXT NOT NULL,
+    data_id CHAR(16) NOT NULL,
+    data_type VARCHAR(16) NOT NULL,
+    created_at TIMESTAMP NOT NULL
+);


### PR DESCRIPTION
## Description
Because I decided to use `gluesql in memory db` as a main state management tool, this pr introduces simple db schema.
Currently `gluesql in memory db` does not support `foreign key`, schema does not have any relations.

Thanks to [azimutt](https://github.com/azimuttapp/azimutt), below image is a visualization of the schema.  
![image](https://user-images.githubusercontent.com/34280965/188545177-3d33b671-de63-4d16-9592-19cb4dc08c31.png)


## Note
- Because this is quite draft version, the schema can change in the future.
- Maybe it would be nice to use `UUID` type instead of `CHAR(16)`?